### PR TITLE
Updating status LED pin to be compatible with more boards.  

### DIFF
--- a/examples/Example10_CheckStatus/Example10_CheckStatus.ino
+++ b/examples/Example10_CheckStatus/Example10_CheckStatus.ino
@@ -28,7 +28,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 #define STATUS_SD_INIT_GOOD 0
 #define STATUS_LAST_COMMAND_SUCCESS 1
@@ -80,7 +80,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example11_ChangeAddress/Example11_ChangeAddress.ino
+++ b/examples/Example11_ChangeAddress/Example11_ChangeAddress.ino
@@ -17,7 +17,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 byte originalAddress = 42; //Original address of the Qwiic OpenLog
 byte newAddress = 30; //Address we want to go to
@@ -85,7 +85,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example1_WritingLog/Example1_WritingLog.ino
+++ b/examples/Example1_WritingLog/Example1_WritingLog.ino
@@ -19,7 +19,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -50,7 +50,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example2_AppendFile/Example2_AppendFile.ino
+++ b/examples/Example2_AppendFile/Example2_AppendFile.ino
@@ -22,7 +22,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 const byte OpenLogAddress = 42; //Default Qwiic OpenLog I2C address
 
@@ -57,7 +57,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example3_CreateFile/Example3_CreateFile.ino
+++ b/examples/Example3_CreateFile/Example3_CreateFile.ino
@@ -19,7 +19,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -45,7 +45,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example4_ReadFileSize/Example4_ReadFileSize.ino
+++ b/examples/Example4_ReadFileSize/Example4_ReadFileSize.ino
@@ -15,7 +15,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -56,7 +56,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example5_ReadFile/Example5_ReadFile.ino
+++ b/examples/Example5_ReadFile/Example5_ReadFile.ino
@@ -16,7 +16,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -99,7 +99,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example6_MakeDirectory/Example6_MakeDirectory.ino
+++ b/examples/Example6_MakeDirectory/Example6_MakeDirectory.ino
@@ -16,7 +16,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -50,7 +50,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example7_ReadDirectoryContents/Example7_ReadDirectoryContents.ino
+++ b/examples/Example7_ReadDirectoryContents/Example7_ReadDirectoryContents.ino
@@ -17,7 +17,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -55,7 +55,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example8_RemoveDirectory/Example8_RemoveDirectory.ino
+++ b/examples/Example8_RemoveDirectory/Example8_RemoveDirectory.ino
@@ -17,7 +17,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -87,7 +87,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }

--- a/examples/Example9_ReadVersion/Example9_ReadVersion.ino
+++ b/examples/Example9_ReadVersion/Example9_ReadVersion.ino
@@ -15,7 +15,7 @@
 #include "SparkFun_Qwiic_OpenLog_Arduino_Library.h"
 OpenLog myLog; //Create instance
 
-int ledPin = 13; //Status LED connected to digital pin 13
+int ledPin = LED_BUILTIN; //Status LED connected to digital pin 13
 
 void setup()
 {
@@ -35,7 +35,7 @@ void loop()
 {
   //Blink the Status LED because we're done!
   digitalWrite(ledPin, HIGH);
-  delay(100);
+  delay(1000);
   digitalWrite(ledPin, LOW);
   delay(1000);
 }


### PR DESCRIPTION
The LED pin in these examples is set to pin 13, which makes incompatible with boards that use a different pin for the LED, e.g. RedBoard Artemis Nano (pin 19.)
The delay time has been updated to 1000 instead of 100 for easier viewability.  
Should fix issue #10 