### PR TITLE
Bugfix: SAMD21 missing bytes in log files / Retry on NAK

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic OpenLog
-version=3.0.2
+version=3.0.3
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the SparkFun Qwiic OpenLog

--- a/src/SparkFun_Qwiic_OpenLog_Arduino_Library.cpp
+++ b/src/SparkFun_Qwiic_OpenLog_Arduino_Library.cpp
@@ -282,6 +282,8 @@ boolean OpenLog::sendCommand(uint8_t registerNumber, String option1)
   {
 #ifndef __SAMD21G18A__
     return (false);
+#else
+    sendCommand(registerNumber, option1); // Retry
 #endif
   }
 
@@ -299,6 +301,8 @@ size_t OpenLog::write(uint8_t character)
   {
 #ifndef __SAMD21G18A__
     return (false);
+#else
+    write(character); // Retry
 #endif
   }
   return (1);
@@ -326,6 +330,8 @@ int OpenLog::writeString(String string)
   {
 #ifndef __SAMD21G18A__
     return (false);
+#else
+    writeString(string); // Retry
 #endif
   }
 
@@ -341,6 +347,8 @@ bool OpenLog::syncFile()
   {
 #ifndef __SAMD21G18A__
     return (false);
+#else
+    syncFile(); // Retry
 #endif
   }
 


### PR DESCRIPTION
This issue/bugfix is a continuation of (closed issue) #3.

On boards with a SAMD21 controller, bytes are sometimes missing from the log files.

I was able to confirm that the missing byte was NOT transmitted by the SAMD21: the problem appears to be on the controller, not on the OpenLog. Further investigation shows that missing characters are associated with a NAK from the OpenLog.

The changes introduced in e31e4b8fd1ede59992cb399d069defd449b639c3 helped a lot, but when a NAK is received from a peripheral, the `write()` function(s) return True - the byte failed to send, but the calling function has no idea.

The changes introduced by this PR attempt to re-transmit bytes that resulted in a NAK. Only the SAMD21 will use this behavior. Testing has shown the problem is resolved.