### PR TITLE
SAMD21 read I2C message length should be 32-bytes

### DIFF
--- a/src/SparkFun_Qwiic_OpenLog_Arduino_Library.h
+++ b/src/SparkFun_Qwiic_OpenLog_Arduino_Library.h
@@ -54,11 +54,6 @@
 //I2C_BUFFER_LENGTH is defined in Wire.H
 #define I2C_BUFFER_LENGTH BUFFER_LENGTH
 
-#elif defined(__SAMD21G18A__)
-
-//SAMD21 uses RingBuffer.h
-#define I2C_BUFFER_LENGTH SERIAL_BUFFER_SIZE
-
 #elif __MK20DX256__
 //Teensy
 


### PR DESCRIPTION
Fixes read issues on SAMD21 that set the I2C message length to 64 (from RingBufferN.h SERIAL_BUFFER_SIZE).  I2C message length should be 32.